### PR TITLE
fix: validar endereço obrigatório no cadastro de usuário

### DIFF
--- a/controllers/authController.js
+++ b/controllers/authController.js
@@ -118,6 +118,13 @@ exports.cadastro = async (req, res) => {
       });
     }
 
+    if (!cep || !rua || !numero || !bairro || !cidade) {
+      return res.status(400).json({
+        success: false,
+        message: "Endereço incompleto. Preencha CEP, rua, número, bairro e cidade",
+      });
+    }
+
     // Verifica se email já existe
     const [emailExists] = await db.query(
       "SELECT id_usuario FROM usuario WHERE email = ?",
@@ -132,7 +139,14 @@ exports.cadastro = async (req, res) => {
     }
 
     // Remove tudo que não for número do CEP
-    const cepLimpo = cep.replace(/\D/g, "");
+    const cepLimpo = String(cep).replace(/\D/g, "");
+
+    if (cepLimpo.length !== 8) {
+      return res.status(400).json({
+        success: false,
+        message: "CEP inválido",
+      });
+    }
 
     // Criptografa senha
     const senhaHash = await bcrypt.hash(senha, 10);


### PR DESCRIPTION
### Motivation
- Corrigir erro que ocorria quando campos de endereço não eram enviados no endpoint de cadastro, evitando exceção ao chamar `replace` em `undefined`.

### Description
- Adiciona validação explícita para `cep`, `rua`, `numero`, `bairro` e `cidade` em `controllers/authController.js` e retorna `400` se estiverem ausentes.
- Converte `cep` com `String(cep).replace(...)` para evitar erro de runtime em entradas inesperadas.
- Valida que o `cep` tenha exatamente 8 dígitos antes de inserir o endereço no banco.

### Testing
- Executado `npm run lint` e passou sem erros.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69933b57ec3c832388009f68ace4919f)